### PR TITLE
Add option to close/reopen dgram socket periodically

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -14,9 +14,10 @@ var dgram = require('dgram'),
  *   @option global_tags {Array=} Optional tags that will be added to every metric
  *   @maxBufferSize      {Number} An optional value for aggregating metrics to send, mainly for performance improvement
  *   @bufferFlushInterval {Number} the time out value to flush out buffer if not
+ *   @option socketRefreshInterval {Number} The maximum amount of time to use one second in milliseconds (default 1 minute)
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, maxBufferSize, bufferFlushInterval) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, maxBufferSize, bufferFlushInterval, socketRefreshInterval) {
   var options = host || {},
          self = this;
 
@@ -31,7 +32,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       mock        : mock === true,
       global_tags : global_tags,
       maxBufferSize : maxBufferSize,
-      bufferFlushInterval: bufferFlushInterval
+      bufferFlushInterval: bufferFlushInterval,
+      socketRefreshInterval: socketRefreshInterval
     };
   }
 
@@ -40,11 +42,13 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.prefix      = options.prefix || '';
   this.suffix      = options.suffix || '';
   this.socket      = dgram.createSocket('udp4');
+  this.socketCreateTime = new Date();
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
   this.maxBufferSize = options.maxBufferSize || 0;
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
   this.buffer = "";
+  this.socketRefreshInterval = options.socketRefreshInterval || 60000; // 1 minute
 
   if(this.maxBufferSize > 0) {
     this.intervalHandle = setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
@@ -260,6 +264,21 @@ Client.prototype.flushQueue = function(){
   this.buffer = "";
 }
 
+
+/**
+ * Close the old socket and create a new one, when desired
+ */
+Client.prototype.refreshSocket = function(){
+  var now = new Date();
+  if ((now - this.socketCreateTime) >= this.socketRefreshInterval) {
+    var newSocket = dgram.createSocket('udp4');
+    var oldSocket = this.socket;
+    this.socket = newSocket;
+    this.socketCreateTime = now;
+    oldSocket.close();
+  }
+}
+
 /**
  *
  * @param message {String}
@@ -267,6 +286,7 @@ Client.prototype.flushQueue = function(){
  */
 Client.prototype.sendMessage = function(message, callback){
   var buf = new Buffer(message);
+  this.refreshSocket();
   this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
 }
 


### PR DESCRIPTION
This will be useful when we are running a service in k8s and sending metrics to the statsd service.
If/when statsd service is moved to a new minion node, the existing dgram socket needs to be closed and a new one opened before the metrics packets will be routed to the correct node (the new location of statsd).

I looked at the alternative node-statsd-client library, but spotted and was able to reproduce a few bugs with this library.  Rather than attempting to fix the bugs in node-statsd-client, I've decided to stick with node-statsd and add the ability to refresh the dgram socket.